### PR TITLE
gpu 최적화 시도...

### DIFF
--- a/infer_hairline_cond_v2.py
+++ b/infer_hairline_cond_v2.py
@@ -176,33 +176,34 @@ def main():
 
     cond_tokens = conditioner(mask_latent, z_bald)
     cond_states = torch.cat([cond_tokens, text_embeddings], dim=1)
-
+    uncond_states = None
     if use_guidance:
         uncond_states = torch.cat([cond_tokens, uncond_embeddings], dim=1)
-        encoder_hidden_states = torch.cat([uncond_states, cond_states], dim=0)
-    else:
-        encoder_hidden_states = cond_states
 
     for t in noise_scheduler.timesteps:
         with torch.no_grad():
             with torch.autocast(
                 device_type="cuda", dtype=weight_dtype, enabled=device.type == "cuda"
             ):
-                latent_model_input = latents
-                mask_input = mask_latent
+                model_input = torch.cat([latents, mask_latent], dim=1)
                 if use_guidance:
-                    latent_model_input = torch.cat([latent_model_input, latent_model_input])
-                    mask_input = torch.cat([mask_input, mask_input])
-
-                noise_pred = unet(
-                    torch.cat([latent_model_input, mask_input], dim=1),
-                    t,
-                    encoder_hidden_states=encoder_hidden_states,
-                ).sample
-
-                if use_guidance:
-                    noise_pred_uncond, noise_pred_text = noise_pred.chunk(2)
+                    noise_pred_uncond = unet(
+                        model_input,
+                        t,
+                        encoder_hidden_states=uncond_states,
+                    ).sample
+                    noise_pred_text = unet(
+                        model_input,
+                        t,
+                        encoder_hidden_states=cond_states,
+                    ).sample
                     noise_pred = noise_pred_uncond + args.guidance_scale * (noise_pred_text - noise_pred_uncond)
+                else:
+                    noise_pred = unet(
+                        model_input,
+                        t,
+                        encoder_hidden_states=cond_states,
+                    ).sample
 
                 latents = noise_scheduler.step(noise_pred, t, latents).prev_sample
 


### PR DESCRIPTION
closes #4

# 개요
infer_hairline_cond_v2.py에서 Classifier-Free Guidance(CFG)처리 방식이 uncond/cond latent를 한 번에 concat -> U-Net forward 1회 구조로 되어 있어, UNet 입력 배치 크기가 즉시 2배가 되어 GPU OOM이 쉽게 발생하는 문제 해결

# 현상
latent = torch.cat([latent_uncond, latent_cond], dim=0)
mask   = torch.cat([mask_uncond, mask_cond], dim=0)
pred = unet(latent, mask, ...)

이 구조는 UNet input batch = 2B 가 되므로, 특히 cross-attention에서 메모리가 급증함.

# 원인
CFG를 한 번에 계산하기 위해 unconditional + conditional을 하나의 batch로 합치는 방식 사용 -> UNet의 forward 입력이 두배(B -> 2B)
Stable Diffusion의 일반적인 CFG는 uncond -> cond -> α·cond + (1–α)·uncond
형태로 두 번 forward 하는 방식이 기본인데 이를 단일 forward로 변경하면서 OOM 발생.

# 수정 내용
- uncond forward 1회
- cond forward 1회
- 두 출력을 guidance scale에 따라 합성
- pred = pred_uncond + guidance_scale * (pred_cond - pred_uncond)

아마 속도는 느려지겟지만 돌아가지 않을까라는 기대를...


